### PR TITLE
PR の author を自動設定する action を追加する

### DIFF
--- a/.github/auto_assign_config.yml
+++ b/.github/auto_assign_config.yml
@@ -1,0 +1,2 @@
+addReviewers: true
+addAssignees: author

--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -1,0 +1,12 @@
+name: 'Auto Assign'
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-assignees:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v2.0.0
+        with:
+          configuration-path: '.github/auto_assign_config.yml'


### PR DESCRIPTION
### 目的
PR 運用の効率化

### 主な変更点
- PR 作成時に自動で assignees に PR 作成者を設定する GitHub Actions を追加する

### 備考
