### PR TITLE
`count` を用いたコンテナの生成例を追加

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/kreuzwerker/docker" {
+  version     = "3.0.2"
+  constraints = "~> 3.0.2"
+  hashes = [
+    "h1:XjdpVL61KtTsuPE8swok3GY8A+Bu3TZs8T2DOEpyiXo=",
+    "zh:15b0a2b2b563d8d40f62f83057d91acb02cd0096f207488d8b4298a59203d64f",
+    "zh:23d919de139f7cd5ebfd2ff1b94e6d9913f0977fcfc2ca02e1573be53e269f95",
+    "zh:38081b3fe317c7e9555b2aaad325ad3fa516a886d2dfa8605ae6a809c1072138",
+    "zh:4a9c5065b178082f79ad8160243369c185214d874ff5048556d48d3edd03c4da",
+    "zh:5438ef6afe057945f28bce43d76c4401254073de01a774760169ac1058830ac2",
+    "zh:60b7fadc287166e5c9873dfe53a7976d98244979e0ab66428ea0dea1ebf33e06",
+    "zh:61c5ec1cb94e4c4a4fb1e4a24576d5f39a955f09afb17dab982de62b70a9bdd1",
+    "zh:a38fe9016ace5f911ab00c88e64b156ebbbbfb72a51a44da3c13d442cd214710",
+    "zh:c2c4d2b1fd9ebb291c57f524b3bf9d0994ff3e815c0cd9c9bcb87166dc687005",
+    "zh:d567bb8ce483ab2cf0602e07eae57027a1a53994aba470fa76095912a505533d",
+    "zh:e83bf05ab6a19dd8c43547ce9a8a511f8c331a124d11ac64687c764ab9d5a792",
+    "zh:e90c934b5cd65516fbcc454c89a150bfa726e7cf1fe749790c7480bbeb19d387",
+    "zh:f05f167d2eaf913045d8e7b88c13757e3cf595dd5cd333057fdafc7c4b7fed62",
+    "zh:fcc9c1cea5ce85e8bcb593862e699a881bd36dffd29e2e367f82d15368659c3d",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~> 3.0.2"
+    }
+  }
+}
+
+provider "docker" {}
+
+module "docker_with_count" {
+  source = "./modules/docker_with_count"
+}

--- a/terraform/modules/docker_with_count/main.tf
+++ b/terraform/modules/docker_with_count/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    // HashiCorp外部のProviderのため，継承ではなくモジュール内にも定義を行う
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~> 3.0.2"
+    }
+  }
+}
+
+resource "docker_image" "nginx" {
+  name         = var.image_name
+  keep_locally = false
+}
+
+resource "docker_container" "nginx" {
+  count = 2
+
+  image = "nginx:latest"
+  name  = "count_${count.index}"
+  ports {
+    internal = 80
+    external = var.external_port[count.index]
+  }
+}

--- a/terraform/modules/docker_with_count/variables.tf
+++ b/terraform/modules/docker_with_count/variables.tf
@@ -1,0 +1,18 @@
+variable "image_name" {
+  type        = string
+  description = "Dockerのイメージ名"
+  default     = "nginx:latest"
+}
+
+variable "external_port" {
+  type        = list(number)
+  description = "Dockerの公開ポート番号"
+  default     = [8080, 8081]
+
+  validation {
+    condition = alltrue([
+      for port in var.external_port : port >= 8080 && port <= 8090
+    ])
+    error_message = "ポート番号は8080〜8090で指定してください（例）"
+  }
+}


### PR DESCRIPTION
### 目的
学習用サンプル

### 主な変更点
- 2個の nginx コンテナを起動する `docker_with_count` モジュールを追加する

### 備考
