### PR TITLE
行末の不要な空白を削除する設定を追加

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,4 @@ root = true
 # Unix-style newlines with a newline ending every file
 [*]
 insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
### 目的
コーディングスタイルの統一

### 主な変更点
`trim_trailing_whitespace` を有効化した

### 備考
