### PR TITLE
output の利用例を追加

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,3 +16,11 @@ module "docker_with_count" {
 module "docker_with_for_each" {
   source = "./modules/docker_with_for_each"
 }
+
+output "docker_with_count_container_id_list" {
+  value = module.docker_with_count.container_id_list
+}
+
+output "docker_with_for_each_container_id_map" {
+  value = module.docker_with_for_each.container_id_map
+}

--- a/terraform/modules/docker_with_count/outputs.tf
+++ b/terraform/modules/docker_with_count/outputs.tf
@@ -1,0 +1,3 @@
+output "container_id_list" {
+  value = [for c in docker_container.nginx : c.id]
+}

--- a/terraform/modules/docker_with_for_each/outputs.tf
+++ b/terraform/modules/docker_with_for_each/outputs.tf
@@ -1,0 +1,5 @@
+output "container_id_map" {
+  value = {
+    for c in docker_container.nginx : c.name => c.id
+  }
+}


### PR DESCRIPTION
### 目的
output による利用例を示す

### 主な変更点
for_each, count によって生成されたコンテナ ID の出力を追加する

### 備考
